### PR TITLE
Reading missing resources marks the resources as missing

### DIFF
--- a/k8s/resource_k8s_manifest.go
+++ b/k8s/resource_k8s_manifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	meta2 "k8s.io/apimachinery/pkg/api/meta"
 	"log"
 	"strings"
 	"time"
@@ -193,6 +194,17 @@ func resourceK8sManifestRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Reading object %s", name)
 	err = client.Get(context.Background(), objectKey, object)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Printf("[INFO] Object missing: %#v", object)
+			d.SetId("")
+			return nil
+		}
+		if meta2.IsNoMatchError(err) {
+			log.Printf("[INFO] Object kind missing: %#v", object)
+			d.SetId("")
+			return nil
+		}
+
 		log.Printf("[DEBUG] Received error: %#v", err)
 		return err
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0

When reading a resources that existed, but now doesnt, the plugin now reports to terraform that the resource is missing, which will cause it to be recreated.

### Additional context

There is also a check for the error that the 'Kind' is missing, this might happen if the resources is a CRD, and the CRD itself has also been removed

### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline (TODO)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
