### PR TITLE
Use dynamic lazy rest mapper to detect new crds instantly

### DIFF
--- a/examples/0.12/example.tf
+++ b/examples/0.12/example.tf
@@ -62,3 +62,13 @@ resource "k8s_manifest" "nginx-pvc" {
   content   = data.template_file.nginx-pvc.rendered
   namespace = "nginx"
 }
+
+resource "k8s_manifest" "crontab-crd" {
+    content   = file("${path.module}/../manifests/crontab-crd.yaml")
+}
+
+resource "k8s_manifest" "crontab-resource" {
+    content   = file("${path.module}/../manifests/crontab-resource.yaml")
+    namespace = "nginx"
+    depends_on = [k8s_manifest.crontab-crd]
+}

--- a/examples/manifests/crontab-crd.yaml
+++ b/examples/manifests/crontab-crd.yaml
@@ -1,0 +1,42 @@
+# Deprecated in v1.16 in favor of apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+    # name must match the spec fields below, and be in the form: <plural>.<group>
+    name: crontabs.stable.example.com
+spec:
+    # group name to use for REST API: /apis/<group>/<version>
+    group: stable.example.com
+    # list of versions supported by this CustomResourceDefinition
+    versions:
+        - name: v1
+            # Each version can be enabled/disabled by Served flag.
+          served: true
+            # One and only one version must be marked as the storage version.
+          storage: true
+    # either Namespaced or Cluster
+    scope: Namespaced
+    names:
+        # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+        plural: crontabs
+        # singular name to be used as an alias on the CLI and for display
+        singular: crontab
+        # kind is normally the CamelCased singular type. Your resource manifests use this.
+        kind: CronTab
+        # shortNames allow shorter string to match your resource on the CLI
+        shortNames:
+            - ct
+    preserveUnknownFields: false
+    validation:
+        openAPIV3Schema:
+            type: object
+            properties:
+                spec:
+                    type: object
+                    properties:
+                        cronSpec:
+                            type: string
+                        image:
+                            type: string
+                        replicas:
+                            type: integer

--- a/examples/manifests/crontab-resource.yaml
+++ b/examples/manifests/crontab-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: "stable.example.com/v1"
+kind: CronTab
+metadata:
+    name: my-new-cron-object
+spec:
+    cronSpec: "* * * * */5"
+    image: my-awesome-cron-image


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #38 
| License         | Apache 2.0


### What's in this PR?
Add explicit dynamic lazy rest mapper, to load new CRD's on demand instantly.


### Why?
The default rest mapper implementation loads crds once and fail if a new crd has been created after initialization.
