### PR TITLE
Do not let Terraform fail if the kubectl does not contain the expected content

### DIFF
--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -288,7 +288,7 @@ func tryLoadingConfigFile(d *schema.ResourceData) (*restclient.Config, error) {
 			log.Printf("[INFO] Unable to load config file as it doesn't exist at %q", path)
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Failed to load config (%s%s): %s", path, ctxSuffix, err)
+		log.Printf("[WARN] Failed to load config (%s%s): %s", path, ctxSuffix, err)
 	}
 
 	log.Printf("[INFO] Successfully loaded config file (%s%s)", path, ctxSuffix)


### PR DESCRIPTION
Please find the initial converstation between @bonifaido and me below.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | [Initial slack discussion](https://community-banzaicloud.slack.com/archives/CESQTK0LD/p1585742323009600)
| License         | Apache 2.0


### What's in this PR?
This PR changes the way how Terraform (or the provider) handles the load process of the kubectl config.

Instead of failing, only a WARNING log message will be produced. I also noticed that the provider will only create an INFO log message, if the path to the kubectl config that was provided is non-existent. Thus I believe a 'malformed' (E.g. empty) config should not cause a failure.

### Why?
This is useful in scenarios where the Terraform code itself will bootstrap the actual environment (In our case Rancher) and hence create the proper kubectl config somewhere in the middle of the Terraform execution.

### Checklist
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
