### PR TITLE
Increase resource deletion timeout to 3 minutes

### DIFF
--- a/k8s/resource_k8s_manifest.go
+++ b/k8s/resource_k8s_manifest.go
@@ -53,7 +53,7 @@ func resourceK8sManifest() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create:  schema.DefaultTimeout(3 * time.Minute),
 			Update:  schema.DefaultTimeout(3 * time.Minute),
-			Delete:  schema.DefaultTimeout(1 * time.Minute),
+			Delete:  schema.DefaultTimeout(3 * time.Minute),
 		},
 	}
 }


### PR DESCRIPTION
Increased deletion timeout of resources from 1 to 3 minutes

| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | mentioned in #44
| License         | Apache 2.0


### What's in this PR?
Increased the deletion timeout of ressources from 1 to 3 minutes

### Why?
Deprovisioning of cloud ressources can sometimes take longer. (i.e. k8s service using a AWS LoadBalancer as mentioned in #44 )
