### PR TITLE
handle multi-document YAMLs without panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 terraform.tfstate
 terraform.tfstate.backup
 .terraform/
+crash.log

--- a/examples/manifests/my-configmap.yaml
+++ b/examples/manifests/my-configmap.yaml
@@ -1,3 +1,5 @@
+---
+
 kind: ConfigMap
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #48 , fixes #7
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Handling multi-document YAMLs in a way that the first non-empty document will be processed only. This fixes an ugly panic with multi-document YAMLs.