### PR TITLE
fix in-cluster loading precedence

### DIFF
--- a/k8s/provider.go
+++ b/k8s/provider.go
@@ -157,26 +157,20 @@ type ProviderConfig struct {
 }
 
 func providerConfigure(d *schema.ResourceData, terraformVersion string) (interface{}, error) {
-	var cfg *restclient.Config
+	cfg := &restclient.Config{}
 	var err error
+	_, configSet := d.GetOk("host")
 	if d.Get("load_config_file").(bool) {
 		// Config file loading
 		cfg, err = tryLoadingConfigFile(d)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	if cfg == nil {
+		if err != nil {
+			return nil, err
+		}
+	} else if !configSet {
 		// Attempt to load in-cluster config
 		cfg, err = restclient.InClusterConfig()
 		if err != nil {
-			// Fallback to standard config if we are not running inside a cluster
-			if err == restclient.ErrNotInCluster {
-				cfg = &restclient.Config{}
-			} else {
-				return nil, fmt.Errorf("Failed to configure: %s", err)
-			}
+			return nil, fmt.Errorf("Failed to configure: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixed the provider configuration loading to work according to the documentation.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The provider wasn't working as expected in-cluster when there were statically defined configuration options, and it was still loading the in-cluster config.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
