### PR TITLE
Add Online and Healthy status

### DIFF
--- a/k8s/resource_k8s_manifest.go
+++ b/k8s/resource_k8s_manifest.go
@@ -149,7 +149,7 @@ func waitForReadyStatus(d *schema.ResourceData, c client.Client, object *unstruc
 				}
 
 				if status.Phase != nil {
-					if *status.Phase == "Active" || *status.Phase == "Bound" || *status.Phase == "Running" || *status.Phase == "Ready" {
+					if *status.Phase == "Active" || *status.Phase == "Bound" || *status.Phase == "Running" || *status.Phase == "Ready" || *status.Phase == "Online" || *status.Phase == "Healthy" {
 						return object, "ready", nil
 					}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | short term solution for #75 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adding "Online" and "Healthy" status phases as "ready" phases for Terraform.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This enables deploy openEBS, which has a desired state of "Online" for the storage pool object and "Healthy" for the storage volume.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)