### PR TITLE
Add GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,29 +148,6 @@ jobs:
                     terraform_version: 0.12.20
                     example_dir: examples/0.12
 
-    integration-test-pre012-k8s1-16:
-        executor: minikube
-        steps:
-            -   integration:
-                    kubernetes_version: v1.16.6
-                    terraform_version: 0.11.14
-                    example_dir: examples/pre0.12
-
-    integration-test-pre012-k8s1-15:
-        executor: minikube
-        steps:
-            -   integration:
-                    kubernetes_version: v1.15.9
-                    terraform_version: 0.11.14
-                    example_dir: examples/pre0.12
-
-    integration-test-pre012-k8s1-14:
-        executor: minikube
-        steps:
-            -   integration:
-                    kubernetes_version: v1.14.10
-                    terraform_version: 0.11.14
-                    example_dir: examples/pre0.12
 
 #     release:
 #         executor: docker
@@ -200,15 +177,6 @@ workflows:
                     requires:
                         - checks
             -   integration-test-012-k8s1-14:
-                    requires:
-                        - checks
-            -   integration-test-pre012-k8s1-16:
-                    requires:
-                        - checks
-            -   integration-test-pre012-k8s1-15:
-                    requires:
-                        - checks
-            -   integration-test-pre012-k8s1-14:
                     requires:
                         - checks
 #             -   release:

--- a/.github/.editorconfig
+++ b/.github/.editorconfig
@@ -1,0 +1,2 @@
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kube: ["1.16.15", "1.17.17", "1.18.20", "1.19.14", "1.20.10", "1.21.4"]
+        kube: ["1.19", "1.20", "1.21"]
         terraform: ["0.12.31"]
 
     steps:
@@ -22,28 +22,35 @@ jobs:
         with:
           go-version: 1.16
 
-      - name: Set up minikube
-        uses: sagikazarmark/setup-minikube-action@v0
-        with:
-          version: v1.23.0
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Launch cluster
+      # See https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1
+      - name: Determine KinD node image version
+        id: node_image
         run: |
-          minikube start --kubernetes-version=v${{ matrix.kube }}
+          case ${{ matrix.kube }} in
+            1.19)
+              NODE_IMAGE=kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729 ;;
+            1.20)
+              NODE_IMAGE=kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9 ;;
+            1.21)
+              NODE_IMAGE=kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6 ;;
+            esac
 
-          METALLB_IP_PREFIX_RANGE=$(minikube ip | sed -r 's/(.*)./\1/')
-          cat ~/.minikube/profiles/minikube/config.json  \
-          | jq '.KubernetesConfig.LoadBalancerStartIP="'${METALLB_IP_PREFIX_RANGE}105'"' \
-          | jq '.KubernetesConfig.LoadBalancerEndIP="'${METALLB_IP_PREFIX_RANGE}120'"' \
-          > ~/.minikube/profiles/minikube/config.json.tmp && mv ~/.minikube/profiles/minikube/config.json.tmp ~/.minikube/profiles/minikube/config.json
+            echo "::set-output name=image::$NODE_IMAGE"
 
-          minikube addons enable metallb
-          minikube addons configure metallb
+      - name: Create KinD cluster
+        uses: helm/kind-action@v1.1.0
+        with:
+          version: v0.11.1
+          node_image: ${{ steps.node_image.outputs.image }}
+          config: hack/kind.yaml
+
+      - name: Configure cluster
+        run: ./hack/setup-kind.sh
 
       - name: Test
-        run: make TERRAFORM_VERSION=${{ matrix.terraform }} test-integration
+        run: make TERRAFORM_VERSION=${{ matrix.terraform }} EXAMPLE_DIR=test/terraform test-integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         kube: ["1.19", "1.20", "1.21"]
-        terraform: ["0.12.31", "0.13.7", "0.14.11", "0.15.5", "1.0.6"]
+        terraform: ["0.12.31", "0.14.11", "0.15.5", "1.0.6"] # skip 0.13.7 for now
 
     steps:
       - name: Set up Go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  integration-test:
+    name: Integration test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        kube: ["1.16.15", "1.17.17", "1.18.20", "1.19.14", "1.20.10", "1.21.4"]
+        terraform: ["0.12.31"]
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Set up minikube
+        uses: sagikazarmark/setup-minikube-action@v0
+        with:
+          version: v1.23.0
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Launch cluster
+        run: |
+          minikube start --kubernetes-version=v${{ matrix.kube }}
+
+          METALLB_IP_PREFIX_RANGE=$(minikube ip | sed -r 's/(.*)./\1/')
+          cat ~/.minikube/profiles/minikube/config.json  \
+          | jq '.KubernetesConfig.LoadBalancerStartIP="'${METALLB_IP_PREFIX_RANGE}105'"' \
+          | jq '.KubernetesConfig.LoadBalancerEndIP="'${METALLB_IP_PREFIX_RANGE}120'"' \
+          > ~/.minikube/profiles/minikube/config.json.tmp && mv ~/.minikube/profiles/minikube/config.json.tmp ~/.minikube/profiles/minikube/config.json
+
+          minikube addons enable metallb
+          minikube addons configure metallb
+
+      - name: Test
+        run: make TERRAFORM_VERSION=${{ matrix.terraform }} test-integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         kube: ["1.19", "1.20", "1.21"]
-        terraform: ["0.12.31"]
+        terraform: ["0.12.31", "0.13.7", "0.14.11", "0.15.5", "1.0.6"]
 
     steps:
       - name: Set up Go

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ terraform.tfstate.backup
 .terraform/
 crash.log
 *.tf
+.terraformrc

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ ifneq (,$(findstring 0.12.,${TERRAFORM_VERSION}))
 	cp hack/versions012.tf ${EXAMPLE_DIR}/versions.tf
 	bin/terraform init ${EXAMPLE_DIR}
 	bin/terraform apply -auto-approve -input=false ${EXAMPLE_DIR}
+else ifneq (,$(findstring 0.13.,${TERRAFORM_VERSION}))
+	cp build/terraform-provider-k8s .
+	cp hack/versions012.tf ${EXAMPLE_DIR}/versions.tf
+	bin/terraform init ${EXAMPLE_DIR}
+	bin/terraform apply -auto-approve -input=false ${EXAMPLE_DIR}
 else
 	mkdir -p build/registry.terraform.io/banzaicloud/k8s/99.99.99/${OS}_amd64
 	cp build/terraform-provider-k8s build/registry.terraform.io/banzaicloud/k8s/99.99.99/${OS}_amd64/
@@ -71,6 +76,9 @@ endif
 test-integration-destroy: EXAMPLE_DIR ?= examples/0.12
 test-integration-destroy: bin/terraform .terraformrc
 ifneq (,$(findstring 0.12.,${TERRAFORM_VERSION}))
+	bin/terraform destroy -auto-approve ${EXAMPLE_DIR}
+	rm terraform-provider-k8s
+else ifneq (,$(findstring 0.13.,${TERRAFORM_VERSION}))
 	bin/terraform destroy -auto-approve ${EXAMPLE_DIR}
 	rm terraform-provider-k8s
 else

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
-OS = $(shell uname)
+OS = $(shell uname | tr A-Z a-z)
 
 BINARY_NAME = terraform-provider-k8s
 
@@ -18,11 +18,13 @@ endif
 TEST_FORMAT = short-verbose
 endif
 
+export TF_CLI_CONFIG_FILE = ${PWD}/.terraformrc
+
 # Dependency versions
 GOTESTSUM_VERSION = 0.3.5
 GOLANGCI_VERSION = 1.17.1
 GORELEASER_VERSION = 0.113.0
-TERRAFORM_VERSION = 0.12.8
+TERRAFORM_VERSION = 1.0.6
 
 GOLANG_VERSION = 1.13
 
@@ -50,31 +52,48 @@ endif
 
 .PHONY: test-integration
 test-integration: EXAMPLE_DIR ?= examples/0.12
-test-integration: build bin/terraform ## Execute integration tests
+test-integration: build bin/terraform .terraformrc ## Execute integration tests
+ifneq (,$(findstring 0.12.,${TERRAFORM_VERSION}))
 	cp build/terraform-provider-k8s .
+	cp hack/versions012.tf ${EXAMPLE_DIR}/versions.tf
 	bin/terraform init ${EXAMPLE_DIR}
-	bin/terraform apply -auto-approve ${EXAMPLE_DIR}
+	bin/terraform apply -auto-approve -input=false ${EXAMPLE_DIR}
+else
+	mkdir -p build/registry.terraform.io/banzaicloud/k8s/99.99.99/${OS}_amd64
+	cp build/terraform-provider-k8s build/registry.terraform.io/banzaicloud/k8s/99.99.99/${OS}_amd64/
+	cp hack/versions.tf ${EXAMPLE_DIR}
+	bin/terraform -chdir=${EXAMPLE_DIR} init
+	bin/terraform -chdir=${EXAMPLE_DIR} apply -auto-approve -input=false
+endif
 	${MAKE} test-integration-destroy EXAMPLE_DIR=${EXAMPLE_DIR}
 
 .PHONY: test-integration-destroy
 test-integration-destroy: EXAMPLE_DIR ?= examples/0.12
-test-integration-destroy:
+test-integration-destroy: bin/terraform .terraformrc
+ifneq (,$(findstring 0.12.,${TERRAFORM_VERSION}))
 	bin/terraform destroy -auto-approve ${EXAMPLE_DIR}
 	rm terraform-provider-k8s
+else
+	bin/terraform -chdir=${EXAMPLE_DIR} destroy -auto-approve
+	rm -rf ${EXAMPLE_DIR}/{.terraform,.terraform.lock.hcl}
+endif
 
 bin/terraform: bin/terraform-${TERRAFORM_VERSION}
 	@ln -sf terraform-${TERRAFORM_VERSION} bin/terraform
 bin/terraform-${TERRAFORM_VERSION}:
 	@mkdir -p bin
-ifeq (${OS}, Darwin)
+ifeq (${OS}, darwin)
 	curl -sfL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_darwin_amd64.zip > bin/terraform.zip
 endif
-ifeq (${OS}, Linux)
+ifeq (${OS}, linux)
 	curl -sfL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip > bin/terraform.zip
 endif
 	unzip -d bin bin/terraform.zip
 	@mv bin/terraform $@
 	rm bin/terraform.zip
+
+.terraformrc:
+	sed "s|PATH|$$PWD/build|" hack/.terraformrc.tpl > .terraformrc
 
 bin/goreleaser: bin/goreleaser-${GORELEASER_VERSION}
 	@ln -sf goreleaser-${GORELEASER_VERSION} bin/goreleaser

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use `go get` to install the provider:
 go get -u github.com/banzaicloud/terraform-provider-k8s
 ```
 
-Register the plugin in `~/.terraformrc` (see [Documentation](https://www.terraform.io/docs/commands/cli-config.html) for Windows users): 
+Register the plugin in `~/.terraformrc` (see [Documentation](https://www.terraform.io/docs/commands/cli-config.html) for Windows users):
 
 ```hcl
 providers {
@@ -155,7 +155,7 @@ resource "k8s_manifest" "nginx-deployment" {
 
 ## Helm workflow
 
-#### Requirements 
+#### Requirements
 
 - Helm 2 or Helm 3
 
@@ -297,6 +297,26 @@ The following arguments are supported:
 gpg --fingerprint $MY_EMAIL
 export GPG_FINGERPRINT="THEF FING ERPR INTO OFTH  EPUB LICK EYOF YOU!"
 goreleaser release --rm-dist -p 2
+```
+
+## Testing
+
+Create a [kind](https://kind.sigs.k8s.io) cluster with the attached configuration file:
+
+```bash
+kind create cluster --config hack/kind.yaml
+```
+
+Once the cluster is running, run the setup script:
+
+```bash
+./hack/setup-kind.sh
+```
+
+Finally, run the integration test suite:
+
+```bash
+make EXAMPLE_DIR=test/terraform test-integration
 ```
 
 [kubernetes-provider]: https://www.terraform.io/docs/providers/kubernetes/index.html

--- a/hack/.editorconfig
+++ b/hack/.editorconfig
@@ -1,0 +1,2 @@
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/hack/.terraformrc.tpl
+++ b/hack/.terraformrc.tpl
@@ -1,0 +1,9 @@
+provider_installation {
+  filesystem_mirror {
+    path    = "PATH"
+    include = ["registry.terraform.io/banzaicloud/k8s"]
+  }
+  direct {
+    exclude = ["registry.terraform.io/banzaicloud/k8s"]
+  }
+}

--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+    - role: control-plane
+      kubeadmConfigPatches:
+        - |
+            kind: InitConfiguration
+            nodeRegistration:
+              kubeletExtraArgs:
+                node-labels: "ingress-ready=true"
+      extraPortMappings:
+          - containerPort: 80
+            hostPort: 2080
+            protocol: TCP
+          - containerPort: 443
+            hostPort: 20443
+            protocol: TCP

--- a/hack/metallb-configmap.yaml
+++ b/hack/metallb-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - METALLB_IP_ADDRESS_RANGE

--- a/hack/setup-kind.sh
+++ b/hack/setup-kind.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Dependencies
+#  - kind >=0.11
+#  - k8s >= 1.19
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+METALLB_VERSION=v0.10.2
+INGRESS_VERSION=controller-v1.0.0
+
+# Fingers crossed this is at least a /24 range
+METALLB_IP_PREFIX_RANGE=$(docker network inspect kind --format '{{(index .IPAM.Config 0).Subnet}}' | sed -r 's/(.*).\/.*/\1/')
+METALLB_IP_ADDRESS_RANGE=$(echo "${METALLB_IP_PREFIX_RANGE}200-${METALLB_IP_PREFIX_RANGE}250" | sed "s/\./\\\./g")
+
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/manifests/namespace.yaml
+kubectl delete secret -n metallb-system memberlist --ignore-not-found=true
+kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/manifests/metallb.yaml
+
+kubectl wait --namespace metallb-system --for=condition=ready pod --selector=app=metallb --timeout=90s
+
+sed "s/METALLB_IP_ADDRESS_RANGE/${METALLB_IP_ADDRESS_RANGE}/" "${SCRIPT_DIR}/metallb-configmap.yaml" | kubectl apply -f -
+
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/${INGRESS_VERSION}/deploy/static/provider/kind/deploy.yaml
+kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
+
+# Patch the ingress class to make it defaul
+kubectl patch ingressclass nginx -p '{"metadata": {"annotations":{"ingressclass.kubernetes.io/is-default-class": "true"}}}'

--- a/hack/versions.tf
+++ b/hack/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    k8s = {
+      source  = "banzaicloud/k8s"
+      version = ">= 0.0.1"
+    }
+  }
+}

--- a/hack/versions012.tf
+++ b/hack/versions012.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,0 +1,2 @@
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/test/manifests/crontab-crd.yaml
+++ b/test/manifests/crontab-crd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.stable.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - ct

--- a/test/manifests/crontab-resource.yaml
+++ b/test/manifests/crontab-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: "stable.example.com/v1"
+kind: CronTab
+metadata:
+    name: my-new-cron-object
+spec:
+    cronSpec: "* * * * */5"
+    image: my-awesome-cron-image

--- a/test/manifests/my-configmap.yaml
+++ b/test/manifests/my-configmap.yaml
@@ -1,0 +1,9 @@
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+    name: my-configmap
+    namespace: default
+data:
+    greeting: ${greeting}

--- a/test/manifests/nginx-deployment.yaml
+++ b/test/manifests/nginx-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: ${replicas}
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/test/manifests/nginx-ingress.yaml
+++ b/test/manifests/nginx-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            path: /
+            backend:
+              service:
+                name: nginx-service
+                port:
+                  number: 80

--- a/test/manifests/nginx-namespace.yaml
+++ b/test/manifests/nginx-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx

--- a/test/manifests/nginx-pvc-pod.yaml
+++ b/test/manifests/nginx-pvc-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pvc-pod
+  labels:
+    app: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx:1.7.9
+  volumes:
+    - name: vol
+      persistentVolumeClaim:
+        claimName: nginx

--- a/test/manifests/nginx-pvc.yaml
+++ b/test/manifests/nginx-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nginx
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/test/manifests/nginx-service.yaml
+++ b/test/manifests/nginx-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+  selector:
+    app: nginx
+  type: LoadBalancer

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -1,0 +1,80 @@
+data "template_file" "my-configmap" {
+  template = file("${path.module}/../manifests/my-configmap.yaml")
+
+  vars = {
+    greeting = var.greeting
+  }
+}
+
+resource "k8s_manifest" "my-configmap" {
+  content = data.template_file.my-configmap.rendered
+}
+
+data "template_file" "nginx-deployment" {
+  template = file("${path.module}/../manifests/nginx-deployment.yaml")
+
+  vars = {
+    replicas = var.replicas
+  }
+}
+
+resource "k8s_manifest" "nginx-deployment" {
+  content = data.template_file.nginx-deployment.rendered
+}
+
+data "template_file" "nginx-namespace" {
+  template = file("${path.module}/../manifests/nginx-namespace.yaml")
+}
+
+resource "k8s_manifest" "nginx-namespace" {
+  content   = data.template_file.nginx-namespace.rendered
+  namespace = "kube-system"
+}
+
+resource "k8s_manifest" "nginx-deployment-with-namespace" {
+  content   = data.template_file.nginx-deployment.rendered
+  namespace = "nginx"
+}
+
+data "template_file" "nginx-service" {
+  template = file("${path.module}/../manifests/nginx-service.yaml")
+}
+
+resource "k8s_manifest" "nginx-service" {
+  content   = data.template_file.nginx-service.rendered
+  namespace = "nginx"
+}
+
+data "template_file" "nginx-ingress" {
+  template = file("${path.module}/../manifests/nginx-ingress.yaml")
+}
+
+resource "k8s_manifest" "nginx-ingress" {
+  content   = data.template_file.nginx-ingress.rendered
+  namespace = "nginx"
+}
+
+data "template_file" "nginx-pvc" {
+  template = file("${path.module}/../manifests/nginx-pvc.yaml")
+}
+
+resource "k8s_manifest" "nginx-pvc" {
+  content   = data.template_file.nginx-pvc.rendered
+  namespace = "nginx"
+}
+
+# Kind local storage provisioner doesn't work without binding the PVC
+resource "k8s_manifest" "nginx-pvc-pod" {
+  content   = file("${path.module}/../manifests/nginx-pvc-pod.yaml")
+  namespace = "nginx"
+}
+
+resource "k8s_manifest" "crontab-crd" {
+    content   = file("${path.module}/../manifests/crontab-crd.yaml")
+}
+
+resource "k8s_manifest" "crontab-resource" {
+    content   = file("${path.module}/../manifests/crontab-resource.yaml")
+    namespace = "nginx"
+    depends_on = [k8s_manifest.crontab-crd]
+}

--- a/test/terraform/variables.tf
+++ b/test/terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "greeting" {
+  type    = string
+  default = "Hello, world!"
+}
+
+variable "replicas" {
+  type    = string
+  default = 3
+}
+

--- a/test/terraform/versions.tf
+++ b/test/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Signed-off-by: Mark Sagi-Kazar <mark.sagikazar@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Add GitHub Actions build

To simplify the Kubernetes manifests, tests are only executed against 1.19, 1.20, 1.21 (1.22 will be added once Kind supports it). This allows us to use the latest stable api versions.


### Why?
It's the new standard within the organization
